### PR TITLE
Move firebase from devDependencies to dependencies

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -2690,7 +2690,7 @@ find-up@^2.0.0, find-up@^2.1.0:
   dependencies:
     locate-path "^2.0.0"
 
-firebase@^4.5.0:
+firebase@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/firebase/-/firebase-4.6.0.tgz#59f68cda7085465b46210f816ffef4e94451d891"
   dependencies:


### PR DESCRIPTION
Firebase was installed as a devDependency. Broke the app in production.