### PR TITLE
Return to '/' when user logged out

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -20,6 +20,7 @@ class App extends Component {
       this.setState({
         user: null,
       });
+      window.location = '/';
     });
   }
 


### PR DESCRIPTION
Returns a user to the main screen when they log out.

Previously, a user could log out & still view their profile.
Worse, they could edit their profile while signed out!

I've changed the Firebase database rules to only allow them to edit if logged in. 

But I think it's best if we also return them to the main screen so they don't get confused.