### PR TITLE
Clean up unused vars in map.js

### DIFF
--- a/src/components/map.js
+++ b/src/components/map.js
@@ -3,7 +3,6 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import './map.css';
-import * as actions from './../actions/actions';
 
 class Map extends Component {
   componentDidMount() {
@@ -86,10 +85,6 @@ class Map extends Component {
   }
 
   render() {
-    const mapStyle = {
-      width: 300,
-      height: 300,
-    };
     return <div ref="map" className="map" />;
   }
 }


### PR DESCRIPTION
I left a few unused variables in map.js.
This PR gets rid of most of the warnings.
I can't get rid of the "'marker' is assigned a value but never used  no-unused-vars" warning because google maps requires it the way it is.