### PR TITLE
Fix last message bug

### DIFF
--- a/src/components/messages.js
+++ b/src/components/messages.js
@@ -36,6 +36,10 @@ class Messages extends Component {
           this.setState({
             messages: parsedMessages,
           });
+        } else {
+          this.setState({
+            messages: [],
+          });
         }
       });
   }


### PR DESCRIPTION
To replicate this bug:
git checkout develop.
sign in.
go to messages, delete them all.
The last message will remain until you navigate away & back to messages.

Fix: Add an else after the if (currentMessages != null) block.
