### PR TITLE
Autofocus on subject when modal opens

### DIFF
--- a/src/components/send.js
+++ b/src/components/send.js
@@ -90,6 +90,7 @@ class Send extends Component {
                 className="edit-subject"
                 ref="subject"
                 placeholder="Subject"
+                autoFocus
                 required
               />
 


### PR DESCRIPTION
This changes the focus so on mobile when you hit message you don't have to scroll to the top to get to the message modal.